### PR TITLE
fix having to not forget to add a space after `!` in txtar test scripts

### DIFF
--- a/testdata/negate_exec.txt
+++ b/testdata/negate_exec.txt
@@ -1,0 +1,5 @@
+[!exec:false] skip
+
+!exec false
+!stderr '.+'
+!stdout '.+'

--- a/testscript.go
+++ b/testscript.go
@@ -643,11 +643,15 @@ func (ts *TestScript) runLine(line string) (runOK bool) {
 	// Command prefix ! means negate the expectations about this command:
 	// go command should fail, match should not be found, etc.
 	neg := false
-	if args[0] == "!" {
+	if strings.HasPrefix(args[0], "!") {
 		neg = true
-		args = args[1:]
-		if len(args) == 0 {
-			ts.Fatalf("! on line by itself")
+		if len(args[0]) == 1 {
+			args = args[1:]
+			if len(args) == 0 {
+				ts.Fatalf("! on line by itself")
+			}
+		} else {
+			args[0] = args[0][1:]
 		}
 	}
 


### PR DESCRIPTION
 Locally addresses https://github.com/rogpeppe/go-internal/issues/190 as they don't seem inclined to fix it (not yet sure why/I asked)