### PR TITLE
no need for unquote

### DIFF
--- a/testdata/testscript_stdout_stderr_error.txt
+++ b/testdata/testscript_stdout_stderr_error.txt
@@ -1,18 +1,17 @@
 # Verify that stdout and stderr get set event when a user-builtin
 # command aborts. Note that we need to assert against stdout
 # because our meta testscript command sees only a single log.
-unquote scripts/testscript.txt
 ! testscript -v scripts
 cmpenv stdout stdout.golden
 
 -- scripts/testscript.txt --
-> printargs hello world
-> echoandexit 1 'this is stdout' 'this is stderr'
+printargs hello world
+echoandexit 1 'this is stdout' 'this is stderr'
 -- stdout.golden --
->  printargs hello world
+> printargs hello world
 [stdout]
 ["printargs" "hello" "world"]
->  echoandexit 1 'this is stdout' 'this is stderr'
+> echoandexit 1 'this is stdout' 'this is stderr'
 [stdout]
 this is stdout
 [stderr]


### PR DESCRIPTION
fix failing tests: it's not needed here and we removed that command (maybe shouldn't have...)